### PR TITLE
Fix for case when mutliple repos and a package may not exist

### DIFF
--- a/NuGet.Extras.Tests/Packages/PackageResolutionManagerTests.cs
+++ b/NuGet.Extras.Tests/Packages/PackageResolutionManagerTests.cs
@@ -56,6 +56,28 @@ namespace NuGet.Extras.Tests.Packages
             return result == null ? "" : result.Version.ToString();
         }
 
+        [TestCase("Assembly.Instrumentation", "1.4", null, true, Result = "2.1")]
+        [TestCase("Assembly.Common", "1.4", null, true, Result = "2.1")]
+        [TestCase("Assembly.Common", "2.9", "[1.0,1.3)", true, Result = "1.2")]
+        [TestCase("Assembly.Common", "2.9", "[1.0,1.3]", true, Result = "1.3")]
+        [TestCase("Assembly.Common", "1.3", null, false, Result = "")]
+        public string ResolvesUsingMultipleRepos(string id, string version, string spec, bool isLatest)
+        {
+            var versionSpec = spec == null ? null : VersionUtility.ParseVersionSpec(spec);
+
+            //Add to appropriate cache we want to test based on whether we have a versionspec or not.
+            var console = new Mock<ILogger>().Object;
+            var cache = new MemoryBasedPackageCache(console);
+
+            //Repository does not have these versions, so any call to it will fail...
+            var resolver = new PackageResolutionManager(console, isLatest, cache);
+            var remoteRepository = Utilities.GetFactory().CreateRepository("MultiAggregate");
+            var result = resolver.ResolveLatestInstallablePackage(remoteRepository, new PackageReference(id, SemanticVersion.Parse(version), versionSpec));
+
+            //Null result when we call ResolveLastestInstallablePackage when PackageResolutionManager not using Latest
+            return result == null ? "" : result.Version.ToString();
+        }
+
         [Test]
         [Ignore("Need to sort out a set of tests here....")]
         public void WillNotUseODataIfPackageLocal()

--- a/NuGet.Extras.Tests/TestObjects/Utilities.cs
+++ b/NuGet.Extras.Tests/TestObjects/Utilities.cs
@@ -31,6 +31,11 @@ namespace NuGet.Extras.Tests.TestObjects
                                       PackageUtility.CreatePackage("Assembly.Data", "1.2"),
                                       PackageUtility.CreatePackage("Assembly.Data", "2.0"),
                                       PackageUtility.CreatePackage("Assembly.Data", "2.1", isLatest: true),
+                                      PackageUtility.CreatePackage("Assembly.Instrumentation"),
+                                      PackageUtility.CreatePackage("Assembly.Instrumentation", "1.1"),
+                                      PackageUtility.CreatePackage("Assembly.Instrumentation", "1.2"),
+                                      PackageUtility.CreatePackage("Assembly.Instrumentation", "2.0"),
+                                      PackageUtility.CreatePackage("Assembly.Instrumentation", "2.1", isLatest: true),
                                   };
 
             var factory = new Mock<IPackageRepositoryFactory>();

--- a/NuGet.Extras/ExtensionMethods/AggregateRepositoryExtensions.cs
+++ b/NuGet.Extras/ExtensionMethods/AggregateRepositoryExtensions.cs
@@ -33,7 +33,7 @@ namespace NuGet.Extras.ExtensionMethods
             var remoteRepo = repository.GetRemoteOnlyAggregateRepository();
             IPackage remotePackage = null;
             if (remoteRepo != null)
-                remotePackage = remoteRepo.GetPackages().Where(p => p.Id.Equals(packageId, StringComparison.OrdinalIgnoreCase) && p.IsLatestVersion).FirstOrDefault();
+                remotePackage = remoteRepo.FindPackagesById(packageId).OrderByDescending(p => p.Version).Where(p => p.IsLatestVersion).FirstOrDefault();
 
             if (localPackage != null && remotePackage != null)
                 return localPackage.Version >= remotePackage.Version ? localPackage : remotePackage;

--- a/NuGet.Extras/ExtensionMethods/AggregateRepositoryExtensions.cs
+++ b/NuGet.Extras/ExtensionMethods/AggregateRepositoryExtensions.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Diagnostics.CodeAnalysis;
 
 namespace NuGet.Extras.ExtensionMethods
 {
@@ -33,7 +34,12 @@ namespace NuGet.Extras.ExtensionMethods
             var remoteRepo = repository.GetRemoteOnlyAggregateRepository();
             IPackage remotePackage = null;
             if (remoteRepo != null)
-                remotePackage = remoteRepo.FindPackagesById(packageId).OrderByDescending(p => p.Version).Where(p => p.IsLatestVersion).FirstOrDefault();
+            {
+                //Copying logic from AggregateRepository, but refining the search
+                Func<IPackageRepository, IPackage> findLatestPackage = Wrap(r => r.GetPackages().Where(p => p.Id.Equals(packageId, StringComparison.OrdinalIgnoreCase) && p.IsLatestVersion).FirstOrDefault());
+                var repo = remoteRepo.Repositories.Select(findLatestPackage);
+                remotePackage = repo.Where(p => p != null).OrderByDescending(p => p.Version).FirstOrDefault();
+            }
 
             if (localPackage != null && remotePackage != null)
                 return localPackage.Version >= remotePackage.Version ? localPackage : remotePackage;
@@ -101,5 +107,21 @@ namespace NuGet.Extras.ExtensionMethods
             });
         }
 
+        //HACK Stolen from NuGet.AggregateRepository.
+        [SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "We want to suppress any exception that we may encounter.")]
+        private static Func<IPackageRepository, T> Wrap<T>(Func<IPackageRepository, T> factory, T defaultValue = default(T))
+        {
+            return repository =>
+            {
+                try
+                {
+                    return factory(repository);
+                }
+                catch (Exception ex)
+                {
+                    return defaultValue;
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
- Use FindPackageById instead of GetPackages, then take latest version.

I put in a test this time :)
